### PR TITLE
fix: 修复静态资源有参数的时候不能正确处理的问题

### DIFF
--- a/src/Webworker.php
+++ b/src/Webworker.php
@@ -211,7 +211,7 @@ class Webworker
 	public function onMessage(TcpConnection $connection, Request $request): void
 	{
 		// 访问资源文件
-		$file = $this->app->getRootPath() . 'public' . $request->uri();
+		$file = $this->app->getRootPath() . 'public' . parse_url($request->uri(), PHP_URL_PATH);
 		// 启用静态文件支持且文件存在
 		if ($this->options['static_support'] && false !== strpos($file, '.php') && is_file($file)) {
 			// 获取if-modified-since头


### PR DESCRIPTION
开发过程中为了避免静态资源缓存会添加一个hash值
比如：base.js?123
这时候直接用$request->uri()获取的是base.js?123,这时候在判断是否是文件就会出错